### PR TITLE
Remove errant text from head of main plugin file

### DIFF
--- a/livechat-wordpress.php
+++ b/livechat-wordpress.php
@@ -1,8 +1,4 @@
 
-Editing:  
-/home/livewp/public_html/wp-content/plugins/livechat-wordpress/livechat-wordpress.php
- Encoding:    Re-open Use Code Editor     Close  Save Changes
-
 <?php
 
 /*


### PR DESCRIPTION
There is artifact text at the head of the plugin file causing PHP errors.  This removes it.
