### PR TITLE
rename admin init function

### DIFF
--- a/livechat-wordpress.php
+++ b/livechat-wordpress.php
@@ -273,7 +273,7 @@ final class RocketChat_LIVEChat
 
 	 */
 
-	public function rocketchat_admin_init()
+	public function rocketchat_livechat_admin_init()
 
 	{
 


### PR DESCRIPTION
Name function for consistency and to match function name passed to WP add_action hook.
Closes #6
